### PR TITLE
Make Windows Build Pass

### DIFF
--- a/CMake/conan.cmake
+++ b/CMake/conan.cmake
@@ -361,11 +361,11 @@ endfunction()
 
 
 macro(conan_load_buildinfo)
-    if(CONAN_CMAKE_MULTI)
-        set(_CONANBUILDINFO conanbuildinfo_multi.cmake)
-    else()
+    #if(CONAN_CMAKE_MULTI)
+    #    set(_CONANBUILDINFO conanbuildinfo_multi.cmake)
+    #else()
         set(_CONANBUILDINFO conanbuildinfo.cmake)
-    endif()
+    #endif()
     # Checks for the existence of conanbuildinfo.cmake, and loads it
     # important that it is macro, so variables defined at parent scope
     if(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${_CONANBUILDINFO}")
@@ -379,8 +379,7 @@ endmacro()
 
 macro(conan_cmake_run)
     parse_arguments(${ARGV})
-
-    if(CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE AND NOT CONAN_EXPORTED)
+    if(CMAKE_MSVC_GENERATOR)
         set(CONAN_CMAKE_MULTI ON)
         message(STATUS "Conan: Using cmake-multi generator")
     else()

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Once you have installed [Conan](https://conan.io/), you need to add the followin
 ### Installing
 Clone this repository and build it with CMake (preferable in a directory outside your source)
 
+NOTE: Due to an issue in the current conan/cmake setup, Windows builds MUST be in Release for the time being.
+
 ## Running the tests
 
 ## Deployment

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,62 @@
+import os
+import shutil
+
+from conans import CMake, ConanFile, tools
+
+
+class CprConan(ConanFile):
+    name = "cpr"
+    version = "1.3.0"
+    license = "MIT License"
+    url = "https://github.com/whoshuu/cpr"
+    description = "C++ Requests is a simple wrapper around libcurl inspired by the excellent Python Requests project."
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "curl_nosignal": [True, False],
+        "use_openssl": [True, False],
+    }
+    default_options = "curl_nosignal=False", "use_openssl=True"
+    # exports = ["CMakeLists.txt"]
+    exports_sources = ["cpr-config.cmake"]
+    generators = "cmake"
+    requires = "libcurl/7.60.0@bincrafters/stable"
+
+    @property
+    def zip_folder_name(self):
+        return "%s-%s" % (self.name, self.version)
+
+    def source(self):
+        zip_name = "%s.tar.gz" % self.version
+        tools.download("https://github.com/whoshuu/cpr/archive/%s" % zip_name, zip_name)
+        tools.check_md5(zip_name, "f9df0c649208b06dd314699b4eb43759")
+        tools.unzip(zip_name)
+        os.unlink(zip_name)
+        with tools.chdir(self.zip_folder_name):
+            tools.replace_in_file('CMakeLists.txt', 'project(cpr)', '''project(cpr)
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()''')
+            tools.replace_in_file('CMakeLists.txt', 'add_subdirectory(opt)', '')
+            #tools.replace_in_file('cpr/CMakeLists.txt', 'add_library(${CPR_LIBRARIES}', 'add_library(${CPR_LIBRARIES} STATIC')
+            tools.replace_in_file('cpr/CMakeLists.txt', '${CURL_INCLUDE_DIRS}', '${CONAN_INCLUDE_DIRS_LIBCURL}')
+            tools.replace_in_file('cpr/CMakeLists.txt', '${CURL_LIBRARIES}', '${CONAN_LIBS_LIBCURL}')
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.definitions["CPR_CURL_NOSIGNAL"] = "ON" if self.options.curl_nosignal else "OFF"
+        cmake.definitions["CMAKE_USE_OPENSSL"] = "ON" if self.options.use_openssl else "OFF"
+        cmake.definitions["BUILD_CPR_TESTS"] = "OFF"
+        cmake.configure(source_dir=self.zip_folder_name)
+        cmake.build()
+
+    def package(self):
+        source_dir = self.zip_folder_name
+        self.copy("cpr-config.cmake", ".", ".")
+        self.copy("*.h", dst="include", src=source_dir + '/include')
+        self.copy("*.lib", dst="lib", keep_path=False)
+        self.copy("*.dll", dst="bin", keep_path=False)
+        self.copy("*.a", dst="lib", keep_path=False)
+        self.copy("*.so*", dst="lib", keep_path=False)
+        self.copy("*.dylib*", dst="lib", keep_path=False)
+
+    def package_info(self):
+        self.cpp_info.libs = ["cpr"]

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -4,3 +4,6 @@ catch2/2.5.0@bincrafters/stable
 
 [generators]
 cmake
+
+[options]
+cpr:use_openssl=False


### PR DESCRIPTION
### Description of work
This issue allows Casset to build in windows by not attempting to automatically detect build type. This issue in the conan/cmake setup will be addressed in full later.

This PR also uses a modified version of CPR which allows us to turn openssl off.

### Issue
Fixes #22 

### Acceptance Criteria
Build in Windows

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
