### PR TITLE
Remove cppcheck from unit test build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,5 +51,4 @@ jobs:
         - mkdir build
         - cd build
         - cmake -DCMAKE_CXX_COMPILER=$COMPILER -DCMAKE_BUILD_TYPE=Debug .. && make
-        - cppcheck --quiet --force --error-exitcode=1 .
         - ./bin/UnitTests


### PR DESCRIPTION
### Description of work
cppcheck was being carried out in the unit test Travis build, as well as the cppcheck build. This PR removes cppcheck from unit testing

### Acceptance Criteria
The unit test travis build should not run a cppcheck
---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
