### PR TITLE
Add Tests to Presenter

### DIFF
--- a/src/API/hdr/IEX.h
+++ b/src/API/hdr/IEX.h
@@ -12,7 +12,20 @@ using json = nlohmann::json;
 
 namespace API {
 
-class IEX {
+class IEXInterface {
+public:
+    virtual json getChart(const std::string &symbol) = 0;
+    virtual json getParsedJson(const std::string &endpoint,
+                               const bool verifySSL) = 0;
+    virtual bool isValidSymbol(const std::string &symbol) = 0;
+
+private:
+    virtual cpr::Response makeGetRequest(const std::string &endpoint,
+                                         const bool verifySSL) = 0;
+    virtual json parseGetRequest(const cpr::Response &response) = 0;
+};
+
+class IEX : public IEXInterface {
 public:
   IEX();
   json getChart(const std::string &symbol);

--- a/src/API/hdr/IEX.h
+++ b/src/API/hdr/IEX.h
@@ -15,14 +15,7 @@ namespace API {
 class IEXInterface {
 public:
     virtual json getChart(const std::string &symbol) = 0;
-    virtual json getParsedJson(const std::string &endpoint,
-                               const bool verifySSL) = 0;
     virtual bool isValidSymbol(const std::string &symbol) = 0;
-
-private:
-    virtual cpr::Response makeGetRequest(const std::string &endpoint,
-                                         const bool verifySSL) = 0;
-    virtual json parseGetRequest(const cpr::Response &response) = 0;
 };
 
 class IEX : public IEXInterface {

--- a/src/API/src/IEX.cpp
+++ b/src/API/src/IEX.cpp
@@ -5,7 +5,7 @@ namespace API {
 IEX::IEX() {
     try {
         m_logger = spdlog::stderr_color_mt("IEX_LOG");
-    } catch (spdlog::spdlog_ex) {
+    } catch (spdlog::spdlog_ex &) {
         m_logger = spdlog::get("IEX_LOG");
     }
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ set(HDR_FILES
 )
 
 find_package(Qt5Core CONFIG REQUIRED)
+find_package(Qt5Gui CONFIG REQUIRED)
 find_package(Qt5Widgets CONFIG REQUIRED)
 
 add_executable(Casset ${SRC_FILES} ${HDR_FILES})
@@ -24,4 +25,5 @@ target_link_libraries(Casset CONAN_PKG::cpr
                              CONAN_PKG::CLI11
                              CONAN_PKG::spdlog
                              Qt5::Core
+                             Qt5::Gui
                              Qt5::Widgets)

--- a/src/UI/hdr/mainwindow.h
+++ b/src/UI/hdr/mainwindow.h
@@ -15,11 +15,11 @@ class MainWindow : public QMainWindow
 public:
     explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
-    virtual void updateStockMessage(const std::string &message);
+    void updateStockMessage(const std::string &message);
     virtual std::string getSymbol();
 
     signals:
-            void ViewButtonClicked();
+            void StockButtonClicked();
 private:
     ::Ui::MainWindow *m_ui;
 

--- a/src/UI/hdr/mainwindow.h
+++ b/src/UI/hdr/mainwindow.h
@@ -15,8 +15,8 @@ class MainWindow : public QMainWindow
 public:
     explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
-    void updateStockMessage(const std::string &message);
-    std::string getSymbol() const;
+    virtual void updateStockMessage(const std::string &message);
+    virtual std::string getSymbol();
 
     signals:
             void ViewButtonClicked();

--- a/src/UI/hdr/presenter.h
+++ b/src/UI/hdr/presenter.h
@@ -9,8 +9,8 @@ namespace UI {
 class Presenter : public QObject {
   Q_OBJECT
 public:
-  Presenter(MainWindow *v);
-  Presenter(MainWindow *v, std::unique_ptr<API::IEXInterface> &iex);
+  explicit Presenter(std::shared_ptr<MainWindow> v);
+  explicit Presenter(std::shared_ptr<MainWindow> v, std::unique_ptr<API::IEXInterface> &iex);
 
 public slots:
   void onStockButtonClicked();
@@ -18,7 +18,7 @@ public slots:
 private:
   virtual void updateStockMessage(const std::string &message);
 
-  MainWindow *m_view = nullptr;
+  std::shared_ptr<MainWindow> m_view = nullptr;
   std::unique_ptr<API::IEXInterface> m_iex;
   std::shared_ptr<spdlog::logger> m_logger;
 };

--- a/src/UI/hdr/presenter.h
+++ b/src/UI/hdr/presenter.h
@@ -13,9 +13,11 @@ public:
   Presenter(MainWindow *v, std::unique_ptr<API::IEXInterface> &iex);
 
 public slots:
-  void onViewButtonClicked();
+  void onStockButtonClicked();
 
 private:
+  virtual void updateStockMessage(const std::string &message);
+
   MainWindow *m_view = nullptr;
   std::unique_ptr<API::IEXInterface> m_iex;
   std::shared_ptr<spdlog::logger> m_logger;

--- a/src/UI/hdr/presenter.h
+++ b/src/UI/hdr/presenter.h
@@ -10,7 +10,7 @@ class Presenter : public QObject {
   Q_OBJECT
 public:
   Presenter(MainWindow *v);
-  Presenter(MainWindow *v, std::unique_ptr<API::IEXInterface> iex);
+  Presenter(MainWindow *v, std::unique_ptr<API::IEXInterface> &iex);
 
 public slots:
   void onViewButtonClicked();

--- a/src/UI/hdr/presenter.h
+++ b/src/UI/hdr/presenter.h
@@ -10,13 +10,14 @@ class Presenter : public QObject {
   Q_OBJECT
 public:
   Presenter(MainWindow *v);
+  Presenter(MainWindow *v, std::unique_ptr<API::IEXInterface> iex);
 
 public slots:
   void onViewButtonClicked();
 
 private:
   MainWindow *m_view = nullptr;
-  API::IEX m_iex;
+  std::unique_ptr<API::IEXInterface> m_iex;
   std::shared_ptr<spdlog::logger> m_logger;
 };
 } // UI

--- a/src/UI/src/mainwindow.cpp
+++ b/src/UI/src/mainwindow.cpp
@@ -13,7 +13,7 @@ MainWindow::MainWindow(QWidget *parent) :
         m_ui->setupUi(this);
         this->setWindowTitle("Casset");
 
-        QObject::connect(m_ui->stockButton, SIGNAL(clicked()), this, SIGNAL(ViewButtonClicked()));
+        QObject::connect(m_ui->stockButton, SIGNAL(clicked()), this, SIGNAL(StockButtonClicked()));
 }
 
 MainWindow::~MainWindow() {

--- a/src/UI/src/mainwindow.cpp
+++ b/src/UI/src/mainwindow.cpp
@@ -20,7 +20,7 @@ MainWindow::~MainWindow() {
     delete m_ui;
 }
 
-std::string MainWindow::getSymbol() const {
+std::string MainWindow::getSymbol() {
   return m_ui->symbolLineEdit->text().toStdString();
 }
 

--- a/src/UI/src/presenter.cpp
+++ b/src/UI/src/presenter.cpp
@@ -13,7 +13,7 @@ namespace UI {
 Presenter::Presenter(MainWindow *v) : m_view(v) {
   this->m_iex = std::make_unique<API::IEX>();
 
-  QObject::connect(m_view, SIGNAL(ViewButtonClicked()), this, SLOT(onViewButtonClicked()));
+  QObject::connect(m_view, SIGNAL(StockButtonClicked()), this, SLOT(onStockButtonClicked()));
   try {
       m_logger = spdlog::stderr_color_mt("PRESENTER_LOG");
   } catch (spdlog::spdlog_ex) {
@@ -24,22 +24,22 @@ Presenter::Presenter(MainWindow *v) : m_view(v) {
 Presenter::Presenter(MainWindow *v, std::unique_ptr<API::IEXInterface> &iex) :
   m_view(v), m_iex(std::move(iex)) {
   // this class is for testing purposes only. iex can be a mocked out API parser
-  QObject::connect(m_view, SIGNAL(ViewButtonClicked()), this, SLOT(onViewButtonClicked()));
+  QObject::connect(m_view, SIGNAL(StockButtonClicked()), this, SLOT(onStockButtonClicked()));
 }
 
-void Presenter::onViewButtonClicked() {
+void Presenter::onStockButtonClicked() {
   std::string symbol = m_view->getSymbol();
   // Stock symbols can only be 4 characters at most
   if (symbol.length() > 4) {
     const std::string message = fmt::format("{} is too long for a stock symbol", symbol);
-    m_view->updateStockMessage(message);
+    updateStockMessage(message);
     return;
   }
 
   // Stock symbols contain alphabetical characters only
   if (!std::regex_match(symbol, std::regex("^[A-Za-z]+$"))) {
-    const std::string message = fmt::format("{} contains not alphabetical characters", symbol);
-    m_view->updateStockMessage(message);
+    const std::string message = fmt::format("{} contains non alphabetical characters", symbol);
+    updateStockMessage(message);
     return;
   }
   // Stock symbols are uppercase
@@ -47,10 +47,14 @@ void Presenter::onViewButtonClicked() {
   if (m_iex->isValidSymbol(symbol)) {
     const json chart = m_iex->getChart(symbol);
     StockInfo stock(symbol, chart);
-    m_view->updateStockMessage(stock.getStockReport());
+    updateStockMessage(stock.getStockReport());
   } else {
     const std::string message = fmt::format("{} was not a recognised stock symbol", symbol);
-    m_view->updateStockMessage(message);
+    updateStockMessage(message);
   }
+}
+
+void Presenter::updateStockMessage(const std::string &message) {
+  m_view->updateStockMessage(message);
 }
 } // UI

--- a/src/UI/src/presenter.cpp
+++ b/src/UI/src/presenter.cpp
@@ -16,7 +16,7 @@ Presenter::Presenter(std::shared_ptr<MainWindow> v) : m_view(v) {
   QObject::connect(m_view.get(), SIGNAL(StockButtonClicked()), this, SLOT(onStockButtonClicked()));
   try {
       m_logger = spdlog::stderr_color_mt("PRESENTER_LOG");
-  } catch (spdlog::spdlog_ex) {
+  } catch (spdlog::spdlog_ex &) {
       m_logger = spdlog::get("PRESENTER_LOG");
   }
 }

--- a/src/UI/src/presenter.cpp
+++ b/src/UI/src/presenter.cpp
@@ -11,12 +11,21 @@ using json = nlohmann::json;
 
 namespace UI {
 Presenter::Presenter(MainWindow *v) : m_view(v) {
+  this->m_iex = std::make_unique<API::IEX>();
+
   QObject::connect(m_view, SIGNAL(ViewButtonClicked()), this, SLOT(onViewButtonClicked()));
   try {
       m_logger = spdlog::stderr_color_mt("PRESENTER_LOG");
   } catch (spdlog::spdlog_ex) {
       m_logger = spdlog::get("PRESENTER_LOG");
   }
+}
+
+Presenter::Presenter(MainWindow *v, std::unique_ptr<API::IEXInterface> iex) : m_view(v) {
+  // this class is for testing purposes only. iex can be a mocked out API parser
+  this->m_iex = iex;
+
+  QObject::connect(m_view, SIGNAL(ViewButtonClicked()), this, SLOT(onViewButtonClicked()));
 }
 
 void Presenter::onViewButtonClicked() {
@@ -36,8 +45,8 @@ void Presenter::onViewButtonClicked() {
   }
   // Stock symbols are uppercase
   std::transform(symbol.begin(), symbol.end(),symbol.begin(), ::toupper);
-  if (m_iex.isValidSymbol(symbol)) {
-    const json chart = m_iex.getChart(symbol);
+  if (m_iex->isValidSymbol(symbol)) {
+    const json chart = m_iex->getChart(symbol);
     StockInfo stock(symbol, chart);
     m_view->updateStockMessage(stock.getStockReport());
   } else {

--- a/src/UI/src/presenter.cpp
+++ b/src/UI/src/presenter.cpp
@@ -10,10 +10,10 @@
 using json = nlohmann::json;
 
 namespace UI {
-Presenter::Presenter(MainWindow *v) : m_view(v) {
+Presenter::Presenter(std::shared_ptr<MainWindow> v) : m_view(v) {
   this->m_iex = std::make_unique<API::IEX>();
 
-  QObject::connect(m_view, SIGNAL(StockButtonClicked()), this, SLOT(onStockButtonClicked()));
+  QObject::connect(m_view.get(), SIGNAL(StockButtonClicked()), this, SLOT(onStockButtonClicked()));
   try {
       m_logger = spdlog::stderr_color_mt("PRESENTER_LOG");
   } catch (spdlog::spdlog_ex) {
@@ -21,10 +21,10 @@ Presenter::Presenter(MainWindow *v) : m_view(v) {
   }
 }
 
-Presenter::Presenter(MainWindow *v, std::unique_ptr<API::IEXInterface> &iex) :
+Presenter::Presenter(std::shared_ptr<MainWindow> v, std::unique_ptr<API::IEXInterface> &iex) :
   m_view(v), m_iex(std::move(iex)) {
   // this class is for testing purposes only. iex can be a mocked out API parser
-  QObject::connect(m_view, SIGNAL(StockButtonClicked()), this, SLOT(onStockButtonClicked()));
+  QObject::connect(m_view.get(), SIGNAL(StockButtonClicked()), this, SLOT(onStockButtonClicked()));
 }
 
 void Presenter::onStockButtonClicked() {

--- a/src/UI/src/presenter.cpp
+++ b/src/UI/src/presenter.cpp
@@ -21,10 +21,9 @@ Presenter::Presenter(MainWindow *v) : m_view(v) {
   }
 }
 
-Presenter::Presenter(MainWindow *v, std::unique_ptr<API::IEXInterface> iex) : m_view(v) {
+Presenter::Presenter(MainWindow *v, std::unique_ptr<API::IEXInterface> &iex) :
+  m_view(v), m_iex(std::move(iex)) {
   // this class is for testing purposes only. iex can be a mocked out API parser
-  this->m_iex = iex;
-
   QObject::connect(m_view, SIGNAL(ViewButtonClicked()), this, SLOT(onViewButtonClicked()));
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,8 @@
 #include <CLI/CLI.hpp>
-#include <QApplication>
+#include <memory>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
+#include <QApplication>
 
 #include "API/hdr/IEX.h"
 #include "UI/hdr/mainwindow.h"
@@ -41,8 +42,7 @@ int main(int argc, char **argv) {
     QApplication app(argc, argv);
     Logger->debug("QApplication created");
 
-    UI::MainWindow *casset_window = new UI::MainWindow();
-    casset_window->setAttribute( Qt::WA_DeleteOnClose );
+    auto casset_window = std::make_shared<UI::MainWindow>();
     UI::Presenter presenter(casset_window);
     Logger->debug("Casset main window created");
     casset_window->show();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,12 +7,21 @@ set(SRC_TEST_FILES
         ../src/API/src/IEX.cpp
         API/stockinfoTest.cpp
         ../src/API/src/stockinfo.cpp
+        UI/presenterTest.cpp
+        ../src/UI/src/presenter.cpp
+        ../src/UI/src/mainwindow.cpp
 )
 
 set(HDR_TEST_FILES
         ../src/API/hdr/IEX.h
         ../src/API/hdr/stockinfo.h
+        ../src/UI/hdr/presenter.h
+        ../src/UI/hdr/mainwindow.h
+        ../src/UI/hdr/mainwindow.ui
 )
+
+find_package(Qt5Core CONFIG REQUIRED)
+find_package(Qt5Widgets CONFIG REQUIRED)
 
 add_executable(UnitTests ${SRC_TEST_FILES} ${HDR_TEST_FILES})
 target_link_libraries(UnitTests CONAN_PKG::catch2
@@ -21,4 +30,6 @@ target_link_libraries(UnitTests CONAN_PKG::catch2
                                 CONAN_PKG::jsonformoderncpp
                                 CONAN_PKG::trompeloeil
                                 CONAN_PKG::spdlog
-                                CONAN_PKG::CLI11)
+                                CONAN_PKG::CLI11
+                                Qt5::Core
+                                Qt5::Widgets)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(HDR_TEST_FILES
 )
 
 find_package(Qt5Core CONFIG REQUIRED)
+find_package(Qt5Gui CONFIG REQUIRED)
 find_package(Qt5Widgets CONFIG REQUIRED)
 
 add_executable(UnitTests ${SRC_TEST_FILES} ${HDR_TEST_FILES})
@@ -32,4 +33,5 @@ target_link_libraries(UnitTests CONAN_PKG::catch2
                                 CONAN_PKG::spdlog
                                 CONAN_PKG::CLI11
                                 Qt5::Core
+                                Qt5::Gui
                                 Qt5::Widgets)

--- a/tests/UI/presenterTest.cpp
+++ b/tests/UI/presenterTest.cpp
@@ -1,6 +1,62 @@
 #include <catch2/catch.hpp>
 #include <catch2/trompeloeil.hpp>
+#include <QApplication>
 
 #include "../../src/UI/hdr/presenter.h"
 #include "../../src/UI/hdr/mainwindow.h"
 
+namespace API {
+class IEXMockFalse : public IEXInterface {
+public:
+    json getChart(const std::string &symbol) override {
+      json j;
+      return j;
+    };
+
+    bool isValidSymbol(const std::string &symbol) override {
+      return false;
+    };
+};
+
+class IEXMockTrue : public IEXInterface {
+public:
+    json getChart(const std::string &symbol) override {
+      json j = {{"open",  10.0},
+                {"close", 50.0},
+                {"low",   5.0},
+                {"high",  55.0},
+                {"date",  "2019-01-01"}};
+      return j;
+    }
+
+    bool isValidSymbol(const std::string &symbol) override {
+      return true;
+    }
+};
+
+} // namespace API
+
+class MainWindowMock : public UI::MainWindow {
+public:
+    MAKE_MOCK0(getSymbol, std::string(), override);
+    MAKE_MOCK1(updateStockMessage, void(const std::string &), override);
+};
+
+SCENARIO("The Presenter object can handle user actions and model updates.") {
+  GIVEN("A presenter object, which holds a view, and can make API calls") {
+    char *argv[] = {"program name", NULL};
+    int argc = sizeof(argv) / sizeof(char*) - 1;
+    QApplication app(argc, argv);
+    UI::MainWindow *casset_window = new MainWindowMock();
+    std::unique_ptr<API::IEXInterface> iex = std::make_unique<API::IEXMockFalse>();
+    UI::Presenter presenter(casset_window, iex);
+    WHEN("The click the button to get stock data for a symbol greater than 4 characters long") {
+      REQUIRE_CALL(*casset_window, getSymbol())
+        .RETURN("aLongStock");
+      THEN("We should expect the view message to explain the stock symbol is too long") {
+        REQUIRE_CALL(*casset_window, updateStockMessage("aLongStock is too long for a stock symbol"));
+      }
+    }
+    delete casset_window;
+  }
+}

--- a/tests/UI/presenterTest.cpp
+++ b/tests/UI/presenterTest.cpp
@@ -63,7 +63,7 @@ SCENARIO("The Presenter object can handle user actions and model updates.") {
     // Start QApplication
     char *argv[] = {"program name", NULL};
     int argc = sizeof(argv) / sizeof(char*) - 1;
-    QApplication app(argc, argv);
+    QApplication qapp(argc, argv);
 
     // Create the presenter with mocked view and IEX
     std::shared_ptr<UI::MainWindow> casset_window = std::make_shared<MainWindowMock>("aLongStock");
@@ -81,7 +81,7 @@ SCENARIO("The Presenter object can handle user actions and model updates.") {
   GIVEN("A presenter with a mocked view which returns a non-alphanumerical stock") {
     char *argv[] = {"program name", NULL};
     int argc = sizeof(argv) / sizeof(char*) - 1;
-    QApplication app(argc, argv);
+    QApplication qapp(argc, argv);
 
     // Create the presenter with mocked view and IEX
     std::shared_ptr<UI::MainWindow> casset_window = std::make_shared<MainWindowMock>("a!a");

--- a/tests/UI/presenterTest.cpp
+++ b/tests/UI/presenterTest.cpp
@@ -1,0 +1,6 @@
+#include <catch2/catch.hpp>
+#include <catch2/trompeloeil.hpp>
+
+#include "../../src/UI/hdr/presenter.h"
+#include "../../src/UI/hdr/mainwindow.h"
+

--- a/tests/UI/presenterTest.cpp
+++ b/tests/UI/presenterTest.cpp
@@ -42,7 +42,7 @@ public:
 class MainWindowMock : public UI::MainWindow {
 public:
   explicit MainWindowMock(const std::string &mock_symbol, QWidget *parent = nullptr) :
-    m_mock_symbol(mock_symbol), UI::MainWindow(parent) {}
+  m_mock_symbol(mock_symbol) {(void)parent;}
   std::string getSymbol() override {
     return m_mock_symbol;
   };
@@ -61,7 +61,8 @@ public:
 SCENARIO("The Presenter object can handle user actions and model updates.") {
   GIVEN("A presenter object, which holds a view, and can make API calls") {
     // Start QApplication
-    char *argv[] = {"program name", NULL};
+    char programName[] = "program name";
+    char *argv[] = {programName, nullptr};
     int argc = sizeof(argv) / sizeof(char*) - 1;
     QApplication qapp(argc, argv);
 
@@ -79,7 +80,8 @@ SCENARIO("The Presenter object can handle user actions and model updates.") {
   }
 
   GIVEN("A presenter with a mocked view which returns a non-alphanumerical stock") {
-    char *argv[] = {"program name", NULL};
+    char programName[] = "program name";
+    char *argv[] = {programName, nullptr};
     int argc = sizeof(argv) / sizeof(char*) - 1;
     QApplication qapp(argc, argv);
 


### PR DESCRIPTION
### Description of work
This adds unit tests to the main window presenter, which was missing from the PR which introduced the gui

Currently, the mocked classes (mainwindow and IEX) do not use trompeloeil, as I couldn't get trompeloeil to work properly with pointers

This PR also turn MainWindow into a shared_ptr

### Issue

*No associated issue*

### Acceptance Criteria
1. Unit tests pass
2. Code review

### Unit Tests
`tests/UI/presenterTest.cpp`

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---
