### PR TITLE
Tweak conanfile to make it easier to run on Linux

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -10,6 +10,7 @@ OpenSSL/1.0.2n@conan/stable
 
 [generators]
 cmake
+virtualrunenv
 
 [options]
 cpr:use_openssl=False
@@ -17,4 +18,5 @@ cpr:use_openssl=False
 [imports]
 bin, *.dll -> ./bin
 bin, *.conf -> ./bin
+lib, *.so* -> ./lib
 plugins, * -> ./plugins


### PR DESCRIPTION
### Description of work

Add virtualrunenv generator to conanfile and outputs libraries to a `lib` directory in the build directory. This makes it easier to run the application on Linux, otherwise it doesn't find some libraries.
